### PR TITLE
Support machine usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For something like database or AWS credentials, you'll want to use (and enforce)
 epicenv set KEY VALUE -e myenv -p
 ```
 
-This will mark the env var as personal, preventing it from being committed to git.
+This will mark the env var as personal, and should be prevent from being committed to git (add something like `.epicenv/*/personal_keys.json` to your `.gitignore`).
 
 If someone sources the environment in the future without setting their own personal value, they will see a warning in the console notifying them that they are missing part of the environment.
 
@@ -146,11 +146,13 @@ You can remove global and personal variables with:
 epicenv rm KEY -e myenv
 ```
 
-### Use in deployments
+## Use in deployments (machine users)
 
-While epicenv was originally designed for managing local environments, it's reasonable to use this system for deployments.
+While epicenv was originally designed for managing local environments, it's reasonable to use this system for deployments. This is done via "machine users", which are effectively users without github accounts (manual key specification).
 
-#### Adding deployment machines
+Personal keys are not supported for machine users, so you'll want to ensure that you create dedicated environments for machine users.
+
+### Managing machine users
 
 To add a machine for deployments:
 
@@ -164,7 +166,7 @@ This will register the machine's public key for decrypting the environment. You 
 epicenv machine rm prod-server -e prod
 ```
 
-#### Using on deployment machines
+### Using machine users
 
 There are two ways to set up epicenv on your deployment machines:
 
@@ -196,11 +198,11 @@ source .epicenv/prod/activate
 npm start
 ```
 
-#### Usage in Docker
+### Usage in Docker
 
 Simply replace your `CMD ...` with `CMD ["bash", "run.sh"]` where the script contains the contents similar to the examples above.
 
-#### Example CI/CD usage
+### Example CI/CD usage
 
 For GitHub Actions:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Currently only supports macOS and Linux_
     * [Deactivate the environment](#deactivate-the-environment)
     * [Commit the `.epicenv` directory](#commit-the-epicenv-directory)
     * [Remove variables](#remove-variables)
+    * [Use in deployments](#use-in-deployments)
   * [Motivation](#motivation)
   * [Safety](#safety)
     * [Encryption](#encryption)
@@ -145,6 +146,73 @@ You can remove global and personal variables with:
 epicenv rm KEY -e myenv
 ```
 
+### Use in deployments
+
+While epicenv was originally designed for managing local environments, it's reasonable to use this system for deployments.
+
+#### Adding deployment machines
+
+To add a machine for deployments:
+
+```bash
+epicenv machine add prod-server /path/to/public_key.pub -e prod
+```
+
+This will register the machine's public key for decrypting the environment. You can also remove machines:
+
+```bash
+epicenv machine rm prod-server -e prod
+```
+
+#### Using on deployment machines
+
+There are two ways to set up epicenv on your deployment machines:
+
+1. With explicit key path:
+```bash
+# 1. Set env vars
+export EPICENV_MACHINE_NAME=prod-server
+export EPICENV_MACHINE_KEY=/path/to/private_key
+
+# 2. Source epic env
+source .epicenv/prod/activate
+
+# 3. Run your app
+./app
+```
+
+2. Using conventional key locations:
+```bash
+# 1. Set env vars
+export EPICENV_MACHINE_NAME=prod-server
+
+# 2. Source epic env
+# EpicEnv will automatically look for private keys in:
+# ~/.ssh/machine_prod-server
+# ~/.ssh/prod-server
+source .epicenv/prod/activate
+
+# 3. Run your app
+npm start
+```
+
+#### Usage in Docker
+
+Simply replace your `CMD ...` with `CMD ["bash", "run.sh"]` where the script contains the contents similar to the examples above.
+
+#### Example CI/CD usage
+
+For GitHub Actions:
+
+```yaml
+steps:
+  - name: Setup deployment environment
+    run: |
+      echo "${{ secrets.DEPLOY_PRIVATE_KEY }}" > ~/.ssh/prod-server
+      chmod 600 ~/.ssh/prod-server
+      export EPICENV_MACHINE_NAME=prod-server
+      source .epicenv/prod/activate
+```
 
 ## Motivation
 

--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -10,9 +10,10 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"os"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func generateAESKey() []byte {

--- a/cmd/file_keys.go
+++ b/cmd/file_keys.go
@@ -14,11 +14,14 @@ type (
 
 	EncryptedKey struct {
 		// GitHub username, there may be many for the same
-		Username  string
+		Username  string `json:",omitempty"`
 		PublicKey string
 
 		// EncryptedSharedKey base64 encoded encrypted bytes
 		EncryptedSharedKey string
+
+		// MachineName is the provided name for machine users
+		MachineName string `json:",omitempty"`
 	}
 )
 

--- a/cmd/machine_add.go
+++ b/cmd/machine_add.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+)
+
+var machineAddCmd = &cobra.Command{
+	Use:   "machine-add",
+	Short: "Add a machine user to the EpicEnv using their public key",
+	Long: `Add a machine user (like production/staging servers) to the EpicEnv using their public key.
+Example: epicenv machine-add prod-server /path/to/public_key.pub`,
+	Run:  runMachineAdd,
+	Args: cobra.ExactArgs(2),
+}
+
+func init() {
+	rootCmd.AddCommand(machineAddCmd)
+}
+
+func runMachineAdd(cmd *cobra.Command, args []string) {
+	machineName := args[0]
+	pubKeyPath := args[1]
+	env := getEnvOrFlag(cmd)
+
+	// Read the public key file
+	pubKeyBytes, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error reading public key file")
+	}
+	pubKey := string(pubKeyBytes)
+
+	// Load existing keys
+	keysFile, err := readKeysFile(env)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error loading keys file")
+	}
+
+	// Check if machine name already exists
+	if lo.ContainsBy(keysFile.EncryptedKeys, func(item EncryptedKey) bool {
+		return item.MachineName == machineName
+	}) {
+		logger.Fatal().Msgf("Machine user %s already exists", machineName)
+	}
+
+	// Load symmetric key
+	symKey, err := loadSymmetricKey(env)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error loading symmetric key")
+	}
+
+	// Encrypt symmetric key with their public key
+	encSymKey, err := encryptWithPublicKey(symKey, pubKey)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error encrypting with public key")
+	}
+
+	// Add the new machine user
+	encKey := EncryptedKey{
+		PublicKey:          pubKey,
+		EncryptedSharedKey: encSymKey,
+		MachineName:        machineName,
+	}
+	keysFile.EncryptedKeys = append(keysFile.EncryptedKeys, encKey)
+
+	// Write the updated keys file
+	err = writeKeysFile(env, *keysFile)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error writing keys file")
+	}
+
+	logger.Info().Msgf("Added machine user %s", machineName)
+}

--- a/cmd/machine_rm.go
+++ b/cmd/machine_rm.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+)
+
+var machineRmCmd = &cobra.Command{
+	Use:   "machine-rm",
+	Short: "Remove a machine user from the environment",
+	Run:   runMachineRm,
+	Args:  cobra.ExactArgs(1),
+}
+
+func init() {
+	rootCmd.AddCommand(machineRmCmd)
+}
+
+func runMachineRm(cmd *cobra.Command, args []string) {
+	machineName := args[0]
+	env := getEnvOrFlag(cmd)
+
+	// Load in the keys
+	keysFile, err := readKeysFile(env)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error reading keys file")
+	}
+
+	// Check if the machine user exists
+	if !lo.ContainsBy(keysFile.EncryptedKeys, func(item EncryptedKey) bool {
+		return item.MachineName == machineName
+	}) {
+		logger.Fatal().Msgf("Machine user %s is not invited to this environment", machineName)
+	}
+
+	// Load the symmetric key (so we know that we are invited to the env)
+	_, err = loadSymmetricKey(env)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error loading symmetric key")
+	}
+
+	// Remove the key
+	keysFile.EncryptedKeys = lo.Filter(keysFile.EncryptedKeys, func(item EncryptedKey, index int) bool {
+		return item.MachineName != machineName
+	})
+
+	// Write the updated keys file
+	err = writeKeysFile(env, *keysFile)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error writing keys file")
+	}
+
+	logger.Info().Msgf("Removed machine user %s **THIS IS NOT A REPLACEMENT FOR ROTATING SECRETS!**", machineName)
+}

--- a/example-run.sh
+++ b/example-run.sh
@@ -1,0 +1,5 @@
+# 1. Source the epic env environment
+source ./epicenv/default/activate
+
+# 2. execute your code
+./app


### PR DESCRIPTION
Allow epicenv to add "machine users" (non-github keys) that can be used for deployment environments.