### PR TITLE
Handle piped stdin in set command without panic

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,14 +22,38 @@ var (
 )
 
 func readStdinHidden(prompt string) string {
-	fmt.Print(prompt)
-	// IDE might complain, but the cast is necessary for some OSs, because Stdin is a var instead of an untyped const
-	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		panic(err)
+	// IDE might complain, but the cast is necessary for some OSs, because Stdin is a var instead of an untyped const.
+	stdinFD := int(syscall.Stdin)
+	isTerminal := term.IsTerminal(stdinFD)
+	if isTerminal {
+		fmt.Print(prompt)
 	}
-	fmt.Println() // Move to the next line after input
-	return string(bytePassword)
+
+	value, err := readInputValue(os.Stdin, stdinFD, isTerminal)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("error reading stdin input")
+	}
+
+	if isTerminal {
+		fmt.Println() // Move to the next line after input.
+	}
+	return value
+}
+
+func readInputValue(input io.Reader, stdinFD int, isTerminal bool) (string, error) {
+	if isTerminal {
+		bytePassword, err := term.ReadPassword(stdinFD)
+		if err != nil {
+			return "", err
+		}
+		return string(bytePassword), nil
+	}
+
+	byteValue, err := io.ReadAll(input)
+	if err != nil {
+		return "", err
+	}
+	return string(byteValue), nil
 }
 
 var ErrEnvDirNotFound = errors.New("epicenv directory not found")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadInputValueFromPipePreservesSingleLineWithoutTrailingNewline(t *testing.T) {
+	expected := strings.Repeat("A", 1700)
+
+	got, err := readInputValue(strings.NewReader(expected), 0, false)
+	if err != nil {
+		t.Fatalf("readInputValue returned error: %v", err)
+	}
+
+	if got != expected {
+		t.Fatalf("value mismatch: got length %d, want length %d", len(got), len(expected))
+	}
+}


### PR DESCRIPTION
## Summary
- avoid calling `term.ReadPassword` when stdin is not a terminal
- read piped/file stdin with `io.ReadAll` so `epicenv set KEY` works with non-interactive input
- add a unit test for single-line input without a trailing newline

## Test plan
- [x] Reproduced panic with `cat /tmp/jwt_no_nl | go run . set -e dev JWT_PRIVATE_KEY` before fix
- [x] Verified no panic after fix (`keys` error reached as expected in uninitialized repo)
- [x] Ran `go test ./cmd -run TestReadInputValueFromPipePreservesSingleLineWithoutTrailingNewline`
- [x] Ran `go test ./... -run TestReadInputValueFromPipePreservesSingleLineWithoutTrailingNewline`
