### PR TITLE
fix(invite): strip comment from --path public keys on write

### DIFF
--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -76,7 +76,16 @@ func runInvite(cmd *cobra.Command, args []string) {
 			logger.Fatal().Err(err).Msgf("error reading key file %s", pathFlag)
 		}
 
-		publicKey := strings.TrimSpace(string(keyData))
+		// Normalize to "<keytype> <base64>", matching the format that
+		// github.com/{user}.keys returns for GitHub-invited users. Local
+		// .pub files typically carry a trailing comment (e.g. "user@host")
+		// which would cause mismatches on the reading side, where the
+		// local file is normalized to two fields before comparison.
+		fields := strings.Fields(string(keyData))
+		if len(fields) < 2 {
+			logger.Fatal().Msgf("public key file %s does not contain a valid key (expected '<keytype> <base64>')", pathFlag)
+		}
+		publicKey := fields[0] + " " + fields[1]
 		foundKeys = []string{publicKey}
 	} else {
 		// Handle GitHub user


### PR DESCRIPTION
## Summary

`invite --path <file>` stored the full trimmed file contents as the `PublicKey`, which for a typical `ssh-keygen`-generated `.pub` file means the entry in `keys.json` ends up looking like:

```
"ssh-rsa AAAAB3Nz... user@host"
```

The reader (`findPrivateKeysForPublicKeys` in `cmd/keys.go`) normalizes local `~/.ssh/*.pub` files to the first two space-separated fields before matching, but does **not** apply that same normalization to entries coming from `keys.json`. For GitHub-invited users this never bites because `github.com/{user}.keys` already returns only `<keytype> <base64>` (no comment). For `invite --path`, the trailing comment is preserved on write but stripped on read, so:

```
"ssh-rsa AAAAB3Nz... user@host" (keys.json)
  vs
"ssh-rsa AAAAB3Nz..."           (normalized ~/.ssh/id_rsa.pub)
```

never matches, and decryption fails with:

```
error loading symmetric key error="did not find any local private keys matching a known public key, are you invited to the <env> environment?"
```

We hit this in production CI: a headless key was invited via `epicenv invite github-actions --path .github/id_rsa.pub`, the committed `.pub` file had the default `GitHubActionEpicEnv` comment, and the CI workflow could never decrypt the env.

## Fix

On the write side, normalize the parsed pub key to exactly `<keytype> <base64>` using `strings.Fields`, matching the shape `getKeysForGithubUsername` already produces. This keeps the format consistent across both invite paths and aligns the stored value with what the reader compares against.

Also fails fast with a clearer error if the file does not look like an SSH public key at all.

## Alternatives considered

- Normalizing on the **read** side too (in `findPrivateKeysForPublicKeys`'s `lo.Contains` step). That's a valid additional fix but doesn't help existing broken `keys.json` files without re-running `invite` — and more importantly, it would mask the real invariant: entries stored under a single env should be normalized consistently. Fixing the write side is the authoritative fix. Happy to add the read-side symmetry in a follow-up if you'd like.
- Trimming comments only when the file looks like it has 3+ fields. No benefit over unconditional `strings.Fields`, and more branches.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Existing `go test ./...` status is unchanged (the two pre-existing failures `TestWrapQuotesIfNeeded` and `TestFindFirstPrivateKeyForPublicKey` also fail on `main@4bc2259` without this patch — they appear env-dependent, not related to this change)