### PR TITLE
fix(envfile): omit personal secrets that were never set

### DIFF
--- a/cmd/envfile.go
+++ b/cmd/envfile.go
@@ -27,6 +27,10 @@ func runEnvfile(cmd *cobra.Command, args []string) {
 
 	// Output in .env format
 	for key, val := range envMap {
+		if val.Personal && !val.PersonalSet {
+			continue
+		}
+
 		// Escape backslashes in the value
 		escapedValue := escapeBackslashes(val.Value)
 

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -42,8 +42,9 @@ func getEnvOrFlag(cmd *cobra.Command) string {
 }
 
 type loadedEnvVar struct {
-	Value    string
-	Personal bool
+	Value       string
+	Personal    bool
+	PersonalSet bool // true when value was loaded from personal_secrets.json
 }
 
 // loadEnv will short circuit fatal exit if it has an unrecoverable error.
@@ -128,8 +129,9 @@ func loadEnvLayer(env string, symKey []byte, envMap map[string]loadedEnvVar) {
 					logger.Fatal().Err(err).Msgf("error decrypting personal environment variable %s", item.Name)
 				}
 				envMap[item.Name] = loadedEnvVar{
-					Value:    decrypted,
-					Personal: true,
+					Value:       decrypted,
+					Personal:    true,
+					PersonalSet: true,
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- `envfile` no longer exports personal variables that only exist as placeholders in `secrets.json` and were never written to `personal_secrets.json`
- Personal variables that were explicitly set (including to an empty string) are still exported with the `#personal` comment

## Test plan
- [ ] Mark a variable as personal in `secrets.json` without adding it to `personal_secrets.json`; confirm `epicenv envfile` omits it
- [ ] Add the same variable to `personal_secrets.json` with an empty value; confirm `epicenv envfile` exports `KEY="" #personal`
- [ ] Add a non-empty personal value; confirm it still exports normally